### PR TITLE
fix: typo README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# web3-mulitcall
+# web3-multicall
 
 [![npm version](https://badge.fury.io/js/%40dopex-io%2Fweb3-multicall.svg)](https://badge.fury.io/js/%40dopex-io%2Fweb3-multicall)
 


### PR DESCRIPTION
### fix typo
- from `web3-mulitcall` to `web3-multicall`
- The guy who found this typo is : @HeesuShin